### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -12,6 +12,8 @@ env:
 
 jobs:
   github-pages:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Potential fix for [https://github.com/robert-bogan/myblog/security/code-scanning/1](https://github.com/robert-bogan/myblog/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job. Since this workflow is deploying to GitHub Pages, it needs to push to the repository, which requires `contents: write`. The best practice is to set this at the job level (for `github-pages`), unless other jobs in the workflow also need permissions. The change should be made by adding a `permissions` block under the `github-pages` job, before `runs-on`. No other code or logic needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
